### PR TITLE
single quoted string literals

### DIFF
--- a/Demoprogramm Kryptofunktionen v2.py
+++ b/Demoprogramm Kryptofunktionen v2.py
@@ -3,28 +3,29 @@
 def byte_xor(ba1, ba2):                                         # XOR für List of Bytes
     return bytes([_a ^ _b for _a, _b in zip(ba1, ba2)])
 
+
 def convert(s):                                                 # List of Bytes to string (binary encoded)
-    str1 = "" 
-    return(str1.join(s)) 
+    str1 = ''
+    return(str1.join(s))
 
 
 # einen Key mit pbkdf2 aus einem Passwort erzeugen
 
 from passlib.hash import pbkdf2_sha256
 
-password = input ("Gib den Schlüssel ein:")
+password = input('Gib den Schlüssel ein: ')
 
-key = pbkdf2_sha256.hash(password, rounds=200000, salt_size=0) 
+key = pbkdf2_sha256.hash(password, rounds=200000, salt_size=0)
 key2 = pbkdf2_sha256.hash(password, rounds=200000, salt_size=0)    # ohne salt gibt es immer das Gleiche
 
-print("ohne Salt")
-print("Die ersten zwei abgeleiteten Schlüssel sind nun:", key, key2)
+print('ohne Salt')
+print('Die ersten zwei abgeleiteten Schlüssel sind nun:', key, key2)
 
 # und mit salt
-key = pbkdf2_sha256.hash(password, rounds=200000, salt_size=16)    
-key2 = pbkdf2_sha256.hash(password, rounds=200000, salt_size=16) 
-print("mit Salt")
-print("Die ersten zwei abgeleiteten Schlüssel sind nun:", key, key2)               # der salt steht im Output
+key = pbkdf2_sha256.hash(password, rounds=200000, salt_size=16)
+key2 = pbkdf2_sha256.hash(password, rounds=200000, salt_size=16)
+print('mit Salt')
+print('Die ersten zwei abgeleiteten Schlüssel sind nun:', key, key2)               # der salt steht im Output
 
 
 # Neuer: Scrypt statt pbkdf2 (Memory-hard) dazu verwenden
@@ -33,35 +34,35 @@ import pyscrypt
 salt = b'aa1f2d3f4d23ac44e9c5a6c3d8f9ee8c'
 passwd = password.encode('utf-8')
 
-skey = pyscrypt.hash(passwd, salt, N = 2048, r = 8, p = 1, dkLen = 32)
-print("Scrypt-abgeleiteter Schlüssel:", skey.hex())                          # key ist nicht druckbar, nur als hex
+skey = pyscrypt.hash(passwd, salt, N=2048, r=8, p=1, dkLen=32)
+print('Scrypt-abgeleiteter Schlüssel:', skey.hex())                          # key ist nicht druckbar, nur als hex
 
 # XOR nur demo
-klartext = b"abcdefghijkl01234567890123456789"  # 32 bytes
-key = b"bacdefghijkl01234567890123456789"  # 32 bytes
+klartext = b'abcdefghijkl01234567890123456789'  # 32 bytes
+key = b'bacdefghijkl01234567890123456789'  # 32 bytes
 
 cryptotext = byte_xor(klartext, key)
-print ("Demo für XOR")
-print ("Klartext:", klartext, "key: ", key, "Cryptotext", cryptotext)       # cryptotext ist nicht druckbar
+print('Demo für XOR')
+print('Klartext:', klartext, 'key:', key, 'Cryptotext:', cryptotext)       # cryptotext ist nicht druckbar
 
 # und wieder entschlüsseln
 klartext = cryptotext  # 32 bytes
 decryptotext = byte_xor(klartext, key)
-print("Wieder entschlüsselt: ", decryptotext)
+print('Wieder entschlüsselt:', decryptotext)
 
 # XOR mit key aus scrypt
-print ("und jetzt mit dem scrypt-key")
+print('und jetzt mit dem scrypt-key')
 
-klartext = "abcdefghijkl01234567890123456789"  # 32 bytes
+klartext = 'abcdefghijkl01234567890123456789'  # 32 bytes
 key = skey
-klartext = klartext.encode("utf-8")
+klartext = klartext.encode('utf-8')
 
 cryptotext = byte_xor(klartext, key)
 
-print ("Klartext:", klartext, "key: ", key, "Cryptotext", cryptotext)       # cryptotext ist nicht druckbar
+print('Klartext:', klartext, 'key:', key, 'Cryptotext:', cryptotext)       # cryptotext ist nicht druckbar
 
 # und wieder entschlüsseln
 
 klartext = byte_xor(cryptotext, key)
 
-print ("Entschlüsselt: ", klartext)
+print('Entschlüsselt:', klartext)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Crypto-Demo
 Ein Demoprogramm, das zeigt wie man aus einem Passwort einen beliebig langen Key generiert, mit pbkdf2 und mit scrypt.
+
+
+## Voraussetzungen
+
+Siehe [requirements.txt](requirements.txt). Installation der Packages mit
+
+```sh
+pip3 install -r requirements.txt 
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+passlib==1.7.4
+pyscrypt==1.6.2


### PR DESCRIPTION
This PR
- unifies all string literals to be single quoted
- adds a `requirements.txt` including the required packages to run the example
- adds a Section "Voraussetzungen" to the README.md